### PR TITLE
Product date cache eviction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=6.0', 'requests', 'zeep', 'xmltodict', 'pandas', 'diskcache', 'appdirs', 'numpy', 'ddt']
+requirements = ['Click>=6.0', 'requests', 'zeep', 'xmltodict', 'pandas', 'diskcache', 'appdirs', 'numpy', 'ddt',
+                'packaging', 'python-dateutil']
 
 setup_requirements = ['pytest-runner', ]
 

--- a/spwc/__init__.py
+++ b/spwc/__init__.py
@@ -7,12 +7,12 @@ __email__ = 'alexis.jeandet@member.fsf.org'
 __version__ = '0.1.0'
 from .common.variable import SpwcVariable
 from .amda import AMDA
-from .cdaweb import cdaweb
+from .cdaweb import cdaweb as cd
 from typing import *
 import functools
 
 amda = AMDA()
-cda = cdaweb()
+cda = cd()
 __PROVIDERS__ = {
     'amda':amda.get_data,
     'cdaweb':cda.get_data

--- a/spwc/amda/amda.py
+++ b/spwc/amda/amda.py
@@ -96,8 +96,8 @@ class AMDA:
         storage = self._pack_inventory()
         AMDA.ObsDataTreeParser.extrac_all(tree, storage)
 
-    def get_token(self, method: str = "SOAP", **kwargs: dict) -> str:
-        return self.METHODS[method.upper()].get_token
+    def get_token(self, **kwargs: dict) -> str:
+        return self.METHODS["REST"].get_token
 
     def _dl_parameter(self, start_time: datetime, stop_time: datetime, parameter_id: str,
                       method: str = "SOAP", **kwargs) -> Optional[SpwcVariable]:
@@ -116,13 +116,14 @@ class AMDA:
         cache_product = f"amda/{parameter_id}"
         start_time = make_utc_datetime(start_time)
         stop_time = make_utc_datetime(stop_time)
+        version = self.dataset[self.parameter[parameter_id]["dataset"]]['lastUpdate']
         result = _cache.get_data(cache_product, DateTimeRange(start_time, stop_time),
                                  partial(self._dl_parameter, parameter_id=parameter_id, method=method),
-                                 fragment_hours=12)
+                                 fragment_hours=12, version=version)
         return result
 
     def get_data(self, path, start_time: datetime, stop_time: datetime):
-        return self.get_parameter(start_time=start_time, stop_time=stop_time,parameter_id=path)
+        return self.get_parameter(start_time=start_time, stop_time=stop_time, parameter_id=path)
 
     def get_obs_data_tree(self, method="SOAP") -> dict:
         datatree = xmltodict.parse(requests.get(

--- a/spwc/amda/amda.py
+++ b/spwc/amda/amda.py
@@ -70,6 +70,8 @@ class AMDA:
         self.dataCenter = {}
         if "AMDA/inventory" in _cache:
             self._unpack_inventory(_cache["AMDA/inventory"])
+        else:
+            self.update_inventory()
 
     def __del__(self):
         _cache["AMDA/inventory"] = self._pack_inventory()

--- a/spwc/amda/amda.py
+++ b/spwc/amda/amda.py
@@ -74,7 +74,7 @@ class AMDA:
             self.update_inventory()
 
     def __del__(self):
-        _cache["AMDA/inventory"] = self._pack_inventory()
+        _cache.set("AMDA/inventory", self._pack_inventory(), expire=7 * 24 * 60 * 60)
 
     def _pack_inventory(self):
         return {

--- a/spwc/amda/soap.py
+++ b/spwc/amda/soap.py
@@ -14,12 +14,6 @@ class AmdaSoap:
         else:
             return None
 
-    @property
-    def get_token(self) -> str:
-        url = self.server_url + "/php/rest/auth.php?"
-        r = requests.get(url)
-        return r.text
-
     def get_obs_data_tree(self):
         resp = self.soap_client.service.getObsDataTree().__json__()
         if resp["success"]:

--- a/spwc/cache/__init__.py
+++ b/spwc/cache/__init__.py
@@ -2,4 +2,3 @@ from appdirs import *
 from .cache import Cache
 
 _cache = Cache(str(user_cache_dir("SciQLop","LPP")))
-

--- a/spwc/cache/cache.py
+++ b/spwc/cache/cache.py
@@ -6,6 +6,9 @@ import pandas as pds
 from ..common.variable import SpwcVariable, from_dataframe
 from ..common.variable import merge as merge_variables
 from datetime import datetime, timedelta, timezone
+from .version import str_to_version, version_to_str, Version
+
+cache_version = str_to_version("1.0")
 
 
 def _round(value: int, factor: int):
@@ -41,6 +44,17 @@ class Cache:
 
     def __init__(self, cache_path: str = ""):
         self._data = dc.Cache(cache_path, size_limit=int(20e9))
+        if self.version < cache_version:
+            self._data.clear()
+            self.version = cache_version
+
+    @property
+    def version(self):
+        return str_to_version(self._data.get("cache/version", default="0.0.0"))
+
+    @version.setter
+    def version(self, v: Union[str, Version]):
+        self._data["cache/version"] = v if type(v) is str else version_to_str(v)
 
     def __del__(self):
         pass

--- a/spwc/cache/cache.py
+++ b/spwc/cache/cache.py
@@ -69,7 +69,7 @@ class Cache:
         return var
 
     def get_data(self, parameter_id: str, dt_range: DateTimeRange,
-                 request: Callable[[datetime, datetime], SpwcVariable], fragment_hours=1, last_update=None) -> Optional[
+                 request: Callable[[datetime, datetime], SpwcVariable], fragment_hours=1, version=None) -> Optional[
         SpwcVariable]:
 
         dt_range = _change_tz(dt_range, timezone.utc)
@@ -83,7 +83,6 @@ class Cache:
         contiguous_fragments = []
         for fragment in fragments:
             key = f"{parameter_id}/{fragment.isoformat()}"
-            var = None
             if key in self._data:
                 var = self._data[key]
                 if isinstance(var, pds.DataFrame):  # convert any remaining DataFrame from previous releases

--- a/spwc/cache/cache.py
+++ b/spwc/cache/cache.py
@@ -94,6 +94,9 @@ class Cache:
             self._add_to_cache(new_var, fragments, parameter_id, fragment_hours, version)
         return var
 
+    def set(self, key, value, expire=None):
+        self._data.set(key, value, expire=expire)
+
     def get_data(self, parameter_id: str, dt_range: DateTimeRange,
                  request: Callable[[datetime, datetime], SpwcVariable], fragment_hours=1, version=None) -> Optional[
         SpwcVariable]:

--- a/spwc/cache/cache.py
+++ b/spwc/cache/cache.py
@@ -1,7 +1,6 @@
 from typing import List, Callable, Optional
 
 from ..common.datetime_range import DateTimeRange
-import numpy as np
 import diskcache as dc
 import pandas as pds
 from ..common.variable import SpwcVariable, from_dataframe
@@ -26,17 +25,6 @@ class Cache:
 
     def __setitem__(self, key, value):
         self._data[key] = value
-
-    # @staticmethod
-    # def _merge_dataframe(df: pds.DataFrame, fragment: pds.DataFrame) -> pds.DataFrame:
-    #    if df is None or len(df) == 0:
-    #        df = fragment
-    #    elif len(fragment):
-    #        if df.index[0] > fragment.index[-1]:
-    #            df = pds.concat([fragment, df])
-    #        else:
-    #            df = pds.concat([df, fragment])
-    #    return df
 
     def _add_to_cache(self, var: SpwcVariable, fragments: List[datetime], parameter_id: str, fragment_duration_hours=1):
         if var is not None:

--- a/spwc/cache/version.py
+++ b/spwc/cache/version.py
@@ -1,0 +1,22 @@
+from packaging import version
+import dateutil, datetime
+from typing import Union
+
+
+def str_to_version(v:str):
+    try:
+        v = version.parse(v)
+    except version.InvalidVersion:
+        try:
+            v = dateutil.parser.parse(v)
+        except ValueError:
+            v = None
+    return v
+
+
+def version_to_str(v:Union[version.Version,datetime.datetime]):
+    if type(v) is version.Version:
+        return str(v)
+    elif type(v) is datetime.datetime:
+        return v.isoformat()
+

--- a/spwc/cache/version.py
+++ b/spwc/cache/version.py
@@ -1,12 +1,12 @@
-from packaging import version
+from packaging.version import Version, parse, InvalidVersion
 import dateutil, datetime
 from typing import Union
 
 
-def str_to_version(v:str):
+def str_to_version(v: str):
     try:
-        v = version.parse(v)
-    except version.InvalidVersion:
+        v = parse(v)
+    except InvalidVersion:
         try:
             v = dateutil.parser.parse(v)
         except ValueError:
@@ -14,9 +14,8 @@ def str_to_version(v:str):
     return v
 
 
-def version_to_str(v:Union[version.Version,datetime.datetime]):
-    if type(v) is version.Version:
+def version_to_str(v: Union[Version, datetime.datetime]):
+    if type(v) is Version:
         return str(v)
     elif type(v) is datetime.datetime:
         return v.isoformat()
-

--- a/spwc/common/datetime_range.py
+++ b/spwc/common/datetime_range.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from copy import copy
 
 
 class DateTimeRange:
@@ -17,7 +18,7 @@ class DateTimeRange:
 
     def intersect(self, other):
         return ((self.stop_time >= other[0]) and (self.start_time <= other[1])) or (
-                    other[0] <= self.start_time <= other[1]) or (other[0] <= self.stop_time <= other[1])
+            other[0] <= self.start_time <= other[1]) or (other[0] <= self.stop_time <= other[1])
 
     def __repr__(self):
         return str(self.start_time.isoformat() + "->" + self.stop_time.isoformat())
@@ -69,6 +70,21 @@ class DateTimeRange:
             else:
                 return [self]
             return diff
+        else:
+            raise TypeError()
+
+    def __mul__(self, other):
+        if type(other) is float:
+            result = copy(self)
+            if other >= 1.:
+                margins = (result.stop_time - result.start_time) * (other - 1.) / 2.
+                result.start_time -= margins
+                result.stop_time += margins
+            else:
+                margins = (result.stop_time - result.start_time) * other / 2.
+                result.start_time += margins
+                result.stop_time -= margins
+            return result
         else:
             raise TypeError()
 

--- a/tests/all.py
+++ b/tests/all.py
@@ -1,0 +1,17 @@
+import unittest
+import os
+try:
+    from teamcity import is_running_under_teamcity
+    from teamcity.unittestpy import TeamcityTestRunner
+except:
+    def is_running_under_teamcity():
+        return False
+
+if __name__ == '__main__':
+    if is_running_under_teamcity():
+        runner = TeamcityTestRunner()
+    else:
+        runner = unittest.TextTestRunner()
+    loader = unittest.TestLoader()
+    suite = loader.discover(os.path.dirname(os.path.abspath(__file__)))
+    runner.run(suite)

--- a/tests/test_amda.py
+++ b/tests/test_amda.py
@@ -6,7 +6,12 @@
 import unittest
 import os
 from datetime import datetime, timezone
-from spwc.amda import AMDA,load_csv
+from spwc.amda import amda
+from spwc.cache import Cache
+from spwc.amda import AMDA, load_csv
+import tempfile
+import shutil
+from ddt import ddt, data, unpack
 
 
 class AMDAModule(unittest.TestCase):
@@ -23,28 +28,36 @@ class AMDAModule(unittest.TestCase):
         self.assertGreater(len(var.time), 0)
         self.assertTrue('MISSION_ID' in var.meta)
 
-class simple_request(unittest.TestCase):
+
+@ddt
+class SimpleRequest(unittest.TestCase):
     def setUp(self):
+        self.default_cache_path = amda._cache._data.directory
+        self.cache_path = tempfile.mkdtemp()
+        amda._cache = Cache(self.cache_path)
         self.ws = AMDA()
 
     def tearDown(self):
-        pass
+        amda._cache = Cache(self.default_cache_path)
+        shutil.rmtree(self.cache_path)
 
-    def test_get_variable(self):
+    @data("REST", "SOAP")
+    def test_get_variable(self, method):
         start_date = datetime(2006, 1, 8, 1, 0, 0, tzinfo=timezone.utc)
         stop_date = datetime(2006, 1, 8, 1, 0, 1, tzinfo=timezone.utc)
         parameter_id = "c1_b_gsm"
-        result = self.ws.get_parameter(start_date, stop_date, parameter_id, method="REST")
+        result = self.ws.get_parameter(start_date, stop_date, parameter_id, method=method)
         self.assertIsNotNone(result)
         start_date = datetime(2016, 1, 8, 1, 0, 0, tzinfo=timezone.utc)
         stop_date = datetime(2016, 1, 8, 1, 0, 1, tzinfo=timezone.utc)
         parameter_id = "c1_hia_prest"
-        result = self.ws.get_parameter(start_date, stop_date, parameter_id, method="REST")
+        result = self.ws.get_parameter(start_date, stop_date, parameter_id, method=method)
         self.assertIsNotNone(result)
 
-    def test_get_variable_over_midnight(self):
+    @data("REST", "SOAP")
+    def test_get_variable_over_midnight(self, method):
         start_date = datetime(2006, 1, 8, 23, 30, 0, tzinfo=timezone.utc)
         stop_date = datetime(2006, 1, 9, 0, 30, 0, tzinfo=timezone.utc)
         parameter_id = "c1_b_gsm"
-        result = self.ws.get_parameter(start_date, stop_date, parameter_id, method="REST")
+        result = self.ws.get_parameter(start_date, stop_date, parameter_id, method=method)
         self.assertIsNotNone(result)

--- a/tests/test_amda.py
+++ b/tests/test_amda.py
@@ -61,3 +61,7 @@ class SimpleRequest(unittest.TestCase):
         parameter_id = "c1_b_gsm"
         result = self.ws.get_parameter(start_date, stop_date, parameter_id, method=method)
         self.assertIsNotNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -214,3 +214,7 @@ class _CacheVersionTest(unittest.TestCase):
     @unpack
     def test_compare_version(self, lhs, rhs, op):
         self.assertTrue(op(str_to_version(lhs), str_to_version(rhs)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,7 @@
 import unittest
 from ddt import ddt, data, unpack
 from datetime import datetime, timedelta, timezone
-from spwc.cache.cache import Cache
+from spwc.cache.cache import Cache, _round_for_cache
 from spwc.common.datetime_range import DateTimeRange
 from spwc.common.variable import SpwcVariable
 import numpy as np
@@ -16,8 +16,9 @@ class _CacheTest(unittest.TestCase):
         self.cache = Cache(self.dirpath)
 
     def _make_data(self, tstart, tend):
-        index = np.array([(tstart + timedelta(minutes=delta)).timestamp() for delta in range(int((tend - tstart).seconds / 60))])
-        data = index/3600.
+        index = np.array(
+            [(tstart + timedelta(minutes=delta)).timestamp() for delta in range(int((tend - tstart).seconds / 60))])
+        data = index / 3600.
         return SpwcVariable(time=index, data=data)
 
     def test_get_less_than_one_hour(self):
@@ -25,8 +26,9 @@ class _CacheTest(unittest.TestCase):
         tend = datetime(2016, 6, 1, 13, 10, tzinfo=timezone.utc)
         var = self.cache.get_data("test_get_less_than_one_hour", DateTimeRange(tstart, tend), self._make_data)
         self.assertIsNotNone(var)
+        test = tstart.timestamp()
         self.assertEqual(var.time[0], tstart.timestamp())
-        self.assertEqual(var.time[-1], (tend-timedelta(minutes=1)).timestamp())
+        self.assertEqual(var.time[-1], (tend - timedelta(minutes=1)).timestamp())
         self.assertEqual(len(var), 10)
 
     def test_get_more_than_one_hour(self):
@@ -35,16 +37,16 @@ class _CacheTest(unittest.TestCase):
         var = self.cache.get_data("test_get_less_than_one_hour", DateTimeRange(tstart, tend), self._make_data)
         self.assertIsNotNone(var)
         self.assertEqual(var.time[0], tstart.timestamp())
-        self.assertEqual(var.time[-1], (tend-timedelta(minutes=1)).timestamp())
+        self.assertEqual(var.time[-1], (tend - timedelta(minutes=1)).timestamp())
         self.assertEqual(len(var), 70)
 
     def test_get_over_midnight(self):
-        tstart = datetime(2016, 6, 1, 23,30, tzinfo=timezone.utc)
+        tstart = datetime(2016, 6, 1, 23, 30, tzinfo=timezone.utc)
         tend = datetime(2016, 6, 2, 0, 30, tzinfo=timezone.utc)
         var = self.cache.get_data("test_get_less_than_one_hour", DateTimeRange(tstart, tend), self._make_data)
         self.assertIsNotNone(var)
         self.assertEqual(var.time[0], tstart.timestamp())
-        self.assertEqual(var.time[-1], (tend-timedelta(minutes=1)).timestamp())
+        self.assertEqual(var.time[-1], (tend - timedelta(minutes=1)).timestamp())
         self.assertEqual(len(var), 60)
 
     def tearDown(self):
@@ -119,3 +121,51 @@ class _DateTimeRangeTest(unittest.TestCase):
     def test_substract_with_wrong_type(self):
         with self.assertRaises(TypeError):
             DateTimeRange(datetime(2006, 1, 8, 3, 0, 0), datetime(2006, 1, 8, 4, 0, 0)) - 1
+
+    @data(
+        (
+            DateTimeRange(datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 1, 1, 1, 0, 0)),
+            1.,
+            DateTimeRange(datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 1, 1, 1, 0, 0))
+        ),
+        (
+            DateTimeRange(datetime(2000, 1, 1, 1, 0, 0), datetime(2000, 1, 1, 2, 0, 0)),
+            2.,
+            DateTimeRange(datetime(2000, 1, 1, 0, 30, 0), datetime(2000, 1, 1, 2, 30, 0))
+        ),
+        (
+            DateTimeRange(datetime(2000, 1, 1, 0, 30, 0), datetime(2000, 1, 1, 2, 30, 0)),
+            .5,
+            DateTimeRange(datetime(2000, 1, 1, 1, 0, 0), datetime(2000, 1, 1, 2, 0, 0))
+        ),
+    )
+    @unpack
+    def test_scale(self, dt_range, factor, expected):
+        self.assertEqual(dt_range * factor, expected)
+
+    @data(
+        (
+            DateTimeRange(datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                          datetime(2000, 1, 1, 1, 0, 0, tzinfo=timezone.utc)),
+            1,
+            DateTimeRange(datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                          datetime(2000, 1, 1, 1, 0, 0, tzinfo=timezone.utc))
+        ),
+        (
+            DateTimeRange(datetime(2000, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+                          datetime(2000, 1, 1, 0, 0, 2, tzinfo=timezone.utc)),
+            1,
+            DateTimeRange(datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                          datetime(2000, 1, 1, 1, 0, 0, tzinfo=timezone.utc))
+        ),
+        (
+            DateTimeRange(datetime(2000, 1, 1, 3, 30, 0, tzinfo=timezone.utc),
+                          datetime(2000, 1, 1, 5, 30, 0, tzinfo=timezone.utc)),
+            12,
+            DateTimeRange(datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                          datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
+        ),
+    )
+    @unpack
+    def test_range_rounding(self, dt_range, fragment_hours, expected):
+        self.assertEqual(_round_for_cache(dt_range, fragment_hours), expected)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,8 +2,10 @@ import unittest
 from ddt import ddt, data, unpack
 from datetime import datetime, timedelta, timezone
 from spwc.cache.cache import Cache, _round_for_cache
+from spwc.cache.version import str_to_version, version_to_str
 from spwc.common.datetime_range import DateTimeRange
 from spwc.common.variable import SpwcVariable
+import operator
 import numpy as np
 
 import tempfile
@@ -169,3 +171,25 @@ class _DateTimeRangeTest(unittest.TestCase):
     @unpack
     def test_range_rounding(self, dt_range, fragment_hours, expected):
         self.assertEqual(_round_for_cache(dt_range, fragment_hours), expected)
+
+
+@ddt
+class _CacheVersionTest(unittest.TestCase):
+
+    @data(
+        ("1.1.1", "1.1.1", operator.eq),
+        ("1.1.1", "1.1.2", operator.lt),
+        ("1.1.1", "1.1.0", operator.gt),
+        ("1.1", "1.1", operator.eq),
+        ("1.1", "1.2", operator.lt),
+        ("1.1", "1.0", operator.gt),
+        ("1", "1", operator.eq),
+        ("1", "2", operator.lt),
+        ("1", "0", operator.gt),
+        ("2019-09-01T20:17:57Z", "2019-09-01T20:17:57Z", operator.eq),
+        ("2019-09-01T20:17:57Z", "2019-09-01T21:17:57Z", operator.lt),
+        ("2019-09-01T22:17:57Z", "2019-09-01T20:17:57Z", operator.gt)
+    )
+    @unpack
+    def test_compare_version(self, lhs, rhs, op):
+        self.assertTrue(op(str_to_version(lhs), str_to_version(rhs)))

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -2,16 +2,24 @@ import unittest
 from ddt import ddt, data
 from datetime import datetime, timezone
 from multiprocessing import dummy
-
+import spwc.cdaweb as cd
 from spwc.cdaweb import cdaweb
+from spwc.cache import Cache
+import tempfile
+import shutil
+
 
 @ddt
-class simple_request(unittest.TestCase):
+class SimpleRequest(unittest.TestCase):
     def setUp(self):
+        self.default_cache_path = cd._cache._data.directory
+        self.cache_path = tempfile.mkdtemp()
+        cd._cache = Cache(self.cache_path)
         self.cd = cdaweb()
 
     def tearDown(self):
-        pass
+        cd._cache = Cache(self.default_cache_path)
+        shutil.rmtree(self.cache_path)
 
     @data(
         {

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -57,3 +57,7 @@ class ConcurrentRequests(unittest.TestCase):
         results = self.pool.map(func, [1] * 8)
         for result in results:
             self.assertIsNotNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_spwc_variable.py
+++ b/tests/test_spwc_variable.py
@@ -76,3 +76,7 @@ class SpwcVariableCompare(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Now each data cache fragment has a version and get discard if newer data is available.

This feature still depend on ability to get product version information on server/provider side.